### PR TITLE
Make purchasing labels configurable

### DIFF
--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -1,5 +1,9 @@
 Spree::Shipment.class_eval do
-  state_machine.before_transition :to => :shipped, :do => :buy_easypost_rate
+  state_machine.before_transition(
+    to: :shipped,
+    do: :buy_easypost_rate,
+    if: -> { Spree::EasyPost::CONFIGS[:purchase_labels?] }
+  )
 
   def tracking_url
     nil # TODO: Work out how to properly generate this

--- a/lib/spree_easypost.rb
+++ b/lib/spree_easypost.rb
@@ -2,6 +2,7 @@ require 'spree_core'
 
 module Spree
   module EasyPost
+    CONFIGS = { purchase_labels?: true }
   end
 end
 


### PR DESCRIPTION
If a store doesnt want to purchase labels through easy post, the
buy_easypost_rate callback can be disabled in an initializer by setting

Spree::EasyPost::CONFIGS[:purchase_labels?] = false
