### PR TITLE
Move EasyPost address logic to a module

### DIFF
--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -1,0 +1,24 @@
+module Spree
+  module EasyPost
+    module AddressDecorator
+      def easypost_address
+        attributes = {
+          street1: address1,
+          street2: address2,
+          city: city,
+          zip: zipcode,
+          phone: phone
+        }
+
+        attributes[:company] = respond_to?(:company)? company : Spree::Store.current.name
+        attributes[:name] = full_name if respond_to?(:full_name)
+        attributes[:state] = state ? state.abbr : state_name
+
+        ::EasyPost::Address.create attributes
+      end
+    end
+  end
+end
+
+Spree::Address.prepend Spree::EasyPost::AddressDecorator
+Spree::StockLocation.prepend Spree::EasyPost::AddressDecorator

--- a/app/models/spree/stock/estimator_decorator.rb
+++ b/app/models/spree/stock/estimator_decorator.rb
@@ -2,8 +2,8 @@ Spree::Stock::Estimator.class_eval do
   def shipping_rates(package)
     order = package.order
 
-    from_address = process_address(package.stock_location)
-    to_address = process_address(order.ship_address)
+    from_address = package.stock_location.easypost_address
+    to_address = order.ship_address.easypost_address
     parcel = build_parcel(package)
     shipment = build_shipment(from_address, to_address, parcel)
     rates = shipment.rates.sort_by { |r| r.rate.to_i }
@@ -46,22 +46,6 @@ Spree::Stock::Estimator.class_eval do
         shipping_categories: [Spree::ShippingCategory.first]
       )
     end
-  end
-
-  def process_address(address)
-    ep_address_attrs = {}
-    # Stock locations do not have "company" attributes,
-
-    ep_address_attrs[:company] = address.respond_to?(:company)? address.company : Spree::Store.current.name
-    ep_address_attrs[:name] = address.full_name if address.respond_to?(:full_name)
-    ep_address_attrs[:street1] = address.address1
-    ep_address_attrs[:street2] = address.address2
-    ep_address_attrs[:city] = address.city
-    ep_address_attrs[:state] = address.state ? address.state.abbr : address.state_name
-    ep_address_attrs[:zip] = address.zipcode
-    ep_address_attrs[:phone] = address.phone
-
-    ::EasyPost::Address.create(ep_address_attrs)
   end
 
   def build_parcel(package)

--- a/spec/easypost/address_decorator_spec.rb
+++ b/spec/easypost/address_decorator_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Address do
+  let(:address) { create :address }
+
+  describe '#easypost_address' do
+    subject { address.easypost_address }
+
+    it { is_expected.to be_a EasyPost::Address }
+
+    it do
+      is_expected.to have_attributes(
+        name: 'John Doe',
+        company: 'Company',
+        street1: '10 Lovely Street',
+        street2: 'Northwest',
+        city: 'Herndon',
+        state: 'AL',
+        zip: '35005',
+        country: 'US',
+        phone: '5555550199'
+      )
+    end
+  end
+end


### PR DESCRIPTION
So that it is more reusable. Also addresses should know how to format
themselves for different integrations
