### PR TITLE
Create a new calculator for each shipping method

### DIFF
--- a/app/models/spree/stock/estimator_decorator.rb
+++ b/app/models/spree/stock/estimator_decorator.rb
@@ -42,7 +42,7 @@ Spree::Stock::Estimator.class_eval do
         admin_name: method_name,
         display_on: :back_end,
         code: rate.service,
-        calculator: Spree::ShippingCalculator.first,
+        calculator: Spree::Calculator::Shipping::FlatRate.create,
         shipping_categories: [Spree::ShippingCategory.first]
       )
     end

--- a/spec/easypost/rate_fetcher_spec.rb
+++ b/spec/easypost/rate_fetcher_spec.rb
@@ -14,4 +14,10 @@ describe 'Spree::Stock::Estimator customizations' do
     expect(rates.all? { |rate| rate.easy_post_shipment_id? }).to be_present
     expect(rates.all? { |rate| rate.easy_post_rate_id? }).to be_present
   end
+
+  it 'create shipping methods for the rates' do
+    order.refresh_shipment_rates
+    rates = order.shipments.first.shipping_rates
+    expect(rates.all? { |rate| rate.shipping_method.present? }).to be_truthy
+  end
 end


### PR DESCRIPTION
By default the preferred amount is 0, which is fine because the
calculator will take the shippning rate amount when estimating packages
