### PR TITLE
Shipping rate logic

### DIFF
--- a/app/models/spree/stock/estimator_decorator.rb
+++ b/app/models/spree/stock/estimator_decorator.rb
@@ -10,17 +10,21 @@ Spree::Stock::Estimator.class_eval do
 
     if rates.any?
       rates.each do |rate|
-        package.shipping_rates << Spree::ShippingRate.new(
+        spree_rate = Spree::ShippingRate.new(
           name: "#{ rate.carrier } #{ rate.service }",
           cost: rate.rate,
           easy_post_shipment_id: rate.shipment_id,
           easy_post_rate_id: rate.id,
           shipping_method: find_or_create_shipping_method(rate)
         )
+
+        package.shipping_rates << spree_rate if spree_rate.shipping_method.frontend?
       end
 
       # Sets cheapest rate to be selected by default
-      package.shipping_rates.first.selected = true
+      if package.shipping_rates.any?
+        package.shipping_rates.min_by(&:cost).selected = true
+      end
 
       package.shipping_rates
     else

--- a/app/models/spree/stock/estimator_decorator.rb
+++ b/app/models/spree/stock/estimator_decorator.rb
@@ -35,17 +35,20 @@ Spree::Stock::Estimator.class_eval do
   # and should not be changed in the admin.
   def find_or_create_shipping_method(rate)
     method_name = "#{ rate.carrier } #{ rate.service }"
+    shipping_method = Spree::ShippingMethod.find_or_initialize_by(admin_name: method_name)
 
-    unless shipping_method = Spree::ShippingMethod.find_by(admin_name: method_name)
-      Spree::ShippingMethod.create(
+    unless shipping_method.persisted?
+      shipping_method.update(
         name: method_name,
         admin_name: method_name,
         display_on: :back_end,
         code: rate.service,
-        calculator: Spree::Calculator::Shipping::FlatRate.create(description: ''),
+        calculator: Spree::Calculator::Shipping::FlatRate.create,
         shipping_categories: [Spree::ShippingCategory.first]
       )
     end
+
+    shipping_method
   end
 
   def build_parcel(package)


### PR DESCRIPTION
Only add shipping rates to packages if they can be displayed on the front end
always associate shipping rates to either an existing shipping rate, or create a new, backend only rate. This is necessary because cartons require the shipping method association. and it is also useful if easypost will not be used for actually fulfilment of the shipments.
