### PR TITLE
Correctly set name on shipping method during creation

### DIFF
--- a/app/models/spree/stock/estimator_decorator.rb
+++ b/app/models/spree/stock/estimator_decorator.rb
@@ -37,10 +37,10 @@ module Spree
       def find_or_create_shipping_method(rate)
         method_name = "#{ rate.carrier } #{ rate.service }"
         Spree::ShippingMethod.find_or_create_by(admin_name: method_name) do |r|
-          r.name = method_name,
-          r.display_on = :back_end,
-          r.code = rate.service,
-          r.calculator = Spree::Calculator::Shipping::FlatRate.create,
+          r.name = method_name
+          r.display_on = :back_end
+          r.code = rate.service
+          r.calculator = Spree::Calculator::Shipping::FlatRate.create
           r.shipping_categories = [Spree::ShippingCategory.first]
         end
       end


### PR DESCRIPTION
The create is a block, but was previously written as if it was
taking parameters. I'm vaguely surprised this worked before...
But it looks like just the name was weird, although still
technically worked, just looked weird.
