### PR TITLE
Remove empty definition for tracking_url

### DIFF
--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -8,10 +8,6 @@ module Spree
       )
     end
 
-    def tracking_url
-      nil # TODO: Work out how to properly generate this
-    end
-
     def easypost_shipment
       if selected_easy_post_shipment_id
         @ep_shipment ||= ::EasyPost::Shipment.retrieve(selected_easy_post_shipment_id)

--- a/spec/decorators/shipment_decorator_spec.rb
+++ b/spec/decorators/shipment_decorator_spec.rb
@@ -8,10 +8,6 @@ RSpec.describe Spree::Shipment, :vcr do
     end
   end
 
-  describe '#tracking_url' do
-    it 'needs to be implemented'
-  end
-
   describe '#easypost_shipment' do
     subject { shipment.easypost_shipment }
 


### PR DESCRIPTION
Things that don't do anyhting aren't useful. Also this is
defined on Spree::Shipment in Solidus and I can't see why
it wouldn't work to just use what's there.
